### PR TITLE
Remove `'` at the end of sha256.

### DIFF
--- a/cfiles.rb
+++ b/cfiles.rb
@@ -2,7 +2,7 @@ class Cfiles < Formula
   desc "ncurses file manager written in C"
   homepage "https://github.com/mananapr/cfiles"
   url "https://github.com/mananapr/cfiles/archive/v1.5.tar.gz"
-  sha256 "6decac548ac8f8b900bfe962407889101438889fab806327e29848f1918aae2d'"
+  sha256 "6decac548ac8f8b900bfe962407889101438889fab806327e29848f1918aae2d"
   revision 1
 
   depends_on "fzf"


### PR DESCRIPTION
Brew was throwing an error:
`ChecksumMismatch: SHA256 mismatch`
`Expected: 6decac548ac8f8b900bfe962407889101438889fab806327e29848f1918aae2d'`
`  Actual: 6decac548ac8f8b900bfe962407889101438889fab806327e29848f1918aae2d`